### PR TITLE
create and configure collection view flow layout for a 3-column grid

### DIFF
--- a/GHFollowers/GHFollowers/Controllers/FollowerListVC.swift
+++ b/GHFollowers/GHFollowers/Controllers/FollowerListVC.swift
@@ -27,16 +27,30 @@ class FollowerListVC: UIViewController {
   }
   
   // MARK: - CUSTOM FUNCTIONS
+  func configureViewController() {
+    view.backgroundColor = .systemBackground
+    navigationController?.navigationBar.prefersLargeTitles = true
+  }
+  
   func configureCollectionView() {
-    collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: UICollectionViewFlowLayout())
+    collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: createThreeColumnFlowLayout())
     view.addSubview(collectionView)
     collectionView.backgroundColor = .systemPink
     collectionView.register(FollowerCell.self, forCellWithReuseIdentifier: FollowerCell.reuseIdentifier)
   }
   
-  func configureViewController() {
-    view.backgroundColor = .systemBackground
-    navigationController?.navigationBar.prefersLargeTitles = true
+  func createThreeColumnFlowLayout() -> UICollectionViewFlowLayout {
+    let width = view.bounds.width
+    let padding: CGFloat = 12
+    let minimumItemSpacing: CGFloat = 10
+    let availableWidth = width - (padding * 2) - (minimumItemSpacing * 2)
+    let itemWidth = availableWidth / 3
+    
+    let flowLayout = UICollectionViewFlowLayout()
+    flowLayout.sectionInset = UIEdgeInsets(top: padding, left: padding, bottom: padding, right: padding)
+    flowLayout.itemSize = CGSize(width: itemWidth, height: itemWidth + 40)
+    
+    return flowLayout
   }
   
   func getFollowers() {


### PR DESCRIPTION
- get view width
- initialize padding for both left and right edges of the screen
- initialize minimum spacing between cells
- calculate available with by subtracting padding for both sides and minimum spacing for both sides of the cells from the view width
- get item width by dividing available width by 3 since we're going for a 3-column grid
- set flow layout section insets and item size
- return flow layout